### PR TITLE
[src] Add buttons in SofaContext to control SOFA scene loading and graph mapping to UE5 objects

### DIFF
--- a/Source/SofaUE5/Private/SofaContext.cpp
+++ b/Source/SofaUE5/Private/SofaContext.cpp
@@ -193,7 +193,7 @@ void ASofaContext::PostEditChangeProperty(FPropertyChangedEvent & PropertyChange
         }
         else if (MemberName.Compare(TEXT("filePath")) == 0)
         {
-            loadSofaScene();
+            //loadSofaScene();
         }
     }
 }

--- a/Source/SofaUE5/Private/SofaContext.cpp
+++ b/Source/SofaUE5/Private/SofaContext.cpp
@@ -193,7 +193,7 @@ void ASofaContext::PostEditChangeProperty(FPropertyChangedEvent & PropertyChange
         }
         else if (MemberName.Compare(TEXT("filePath")) == 0)
         {
-            //loadSofaScene();
+            loadSofaScene();
         }
     }
 }
@@ -287,8 +287,12 @@ void ASofaContext::createSofaContext()
     }
 
 
-    if (!filePath.FilePath.IsEmpty())
+    if (!filePath.FilePath.IsEmpty()) {
         loadSofaScene();
+
+        if (m_status != -1)
+            this->reconnectNodeGraph();
+    }
 }
 
 
@@ -313,7 +317,7 @@ void ASofaContext::loadSofaScene()
         UE_LOG(SUnreal_log, Log, TEXT("## ASofaContext::loadSofaScene: Scene loading with success: %s"), *my_filePath);
     }
 
-    FPlatformProcess::Sleep(0.01f);
+    //FPlatformProcess::Sleep(0.01f);
 
     // Pass default scene parameter
    // this->setDT(Dt);
@@ -321,6 +325,15 @@ void ASofaContext::loadSofaScene()
 
     // Start parsing scene loaded in SOFA
     // Create the actor of the scene:
+   
+    //if (m_isMsgHandlerActivated == true)
+    //    catchSofaMessages();
+
+    //m_status++;
+}
+
+void ASofaContext::mapSofaScene()
+{
     if (m_status == -1) {
         this->loadNodeGraph();
     }
@@ -329,9 +342,6 @@ void ASofaContext::loadSofaScene()
         this->reconnectNodeGraph();
 
     }
-    //if (m_isMsgHandlerActivated == true)
-    //    catchSofaMessages();
-
     m_status++;
 }
 

--- a/Source/SofaUE5/Public/SofaContext.h
+++ b/Source/SofaUE5/Public/SofaContext.h
@@ -52,6 +52,9 @@ public:
 
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
+    UFUNCTION(CallInEditor, Category = "Sofa")
+    void loadSofaScene();
+
 #if WITH_EDITOR
     virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
@@ -83,7 +86,7 @@ protected:
     void catchSofaMessages();
 
     void createSofaContext();
-    void loadSofaScene();
+    
 
     void loadDefaultPlugin();
 

--- a/Source/SofaUE5/Public/SofaContext.h
+++ b/Source/SofaUE5/Public/SofaContext.h
@@ -55,6 +55,9 @@ public:
     UFUNCTION(CallInEditor, Category = "Sofa")
     void loadSofaScene();
 
+    UFUNCTION(CallInEditor, Category = "Sofa")
+    void mapSofaScene();
+
 #if WITH_EDITOR
     virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif


### PR DESCRIPTION
Add a first button to load the SOFA scene, it should not be called during parameter setting as it is an unstable state for UE5 life cycle.

Add a second button to parse the SOFA scene a create UE5 actors. Split in 2 buttons to make sure loading has finished in backend before accessing and mapping objects